### PR TITLE
use logger

### DIFF
--- a/src/ezstd_nif.erl
+++ b/src/ezstd_nif.erl
@@ -13,7 +13,7 @@
 
 load_nif() ->
     SoName = get_priv_path(?MODULE),
-    io:format(<<"Loading library: ~p ~n">>, [SoName]),
+    logger:debug(<<"Loading library: ~p ~n">>, [SoName]),
     ok = erlang:load_nif(SoName, 0).
 
 get_priv_path(File) ->


### PR DESCRIPTION
Use the logger instead of `stdout` - allows more control over when `"Loading..."` message is printed. For example, tests that use the library can capture the log entry so that extraneous messages don't print with the rest of the test results.