### PR TITLE
Add LD_FLAGS for Darwin build

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -57,6 +57,9 @@ BuildLibrary()
             export CFLAGS="-fPIC"
             export CXXFLAGS="-fPIC"
             ;;
+        Darwin)
+            export LD_FLAGS="-lz"
+            ;;
         *)
             ;;
     esac


### PR DESCRIPTION
I was getting linking errors when trying to build on an M1 Mac. This seemed to fix