### PR TITLE
Update to zstd 1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## [Zstd][1] binding for Erlang
 
-This binding is based on zstd v1.5.2. In case you want to modify the zstd version you can change `ZSTD_TAG` from `build_deps.sh`
+This binding is based on zstd v1.5.4. In case you want to modify the zstd version you can change `ZSTD_TAG` from `build_deps.sh`
 
 ## API
 

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -11,7 +11,7 @@ CPUS=`getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu`
 ZSTD_DESTINATION=zstd
 ZSTD_REPO=https://github.com/facebook/zstd.git
 ZSTD_BRANCH=master
-ZSTD_TAG=v1.5.2
+ZSTD_TAG=v1.5.4
 ZSTD_SUCCESS=lib/libzstd.a
 
 fail_check()

--- a/c_src/ezstd_nif.cc
+++ b/c_src/ezstd_nif.cc
@@ -133,7 +133,7 @@ static ERL_NIF_TERM zstd_nif_decompress_using_ddict(ErlNifEnv* env, int argc, co
       return make_error(env, "failed to alloc");
     }
 
-    uint64_t uncompressed_size = ZSTD_getDecompressedSize(bin.data, bin.size);
+    uint64_t uncompressed_size = ZSTD_getFrameContentSize(bin.data, bin.size);
 
     ERL_NIF_TERM out_term;
     uint8_t *destination_buffer = enif_make_new_binary(env, uncompressed_size, &out_term);
@@ -257,7 +257,7 @@ static ERL_NIF_TERM zstd_nif_decompress(ErlNifEnv* env, int argc, const ERL_NIF_
     if(!enif_inspect_binary(env, argv[0], &bin))
         return make_badarg(env);
 
-    uint64_t uncompressed_size = ZSTD_getDecompressedSize(bin.data, bin.size);
+    uint64_t uncompressed_size = ZSTD_getFrameContentSize(bin.data, bin.size);
 
     ERL_NIF_TERM out_term;
     uint8_t *destination_buffer = enif_make_new_binary(env, uncompressed_size, &out_term);


### PR DESCRIPTION
1.5.4 has some major performance improvements:
https://github.com/facebook/zstd/releases/tag/v1.5.4

`ZSTD_getDecompressedSize()` is deprecated and has been replaced with `ZSTD_getFrameContentSize()` as per docs at:
https://raw.githack.com/facebook/zstd/release/doc/zstd_manual.html