### PR TITLE
Fix zstd git reference

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -10,7 +10,7 @@ CPUS=`getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu`
 
 ZSTD_DESTINATION=zstd
 ZSTD_REPO=https://github.com/facebook/zstd.git
-ZSTD_BRANCH=master
+ZSTD_BRANCH=release
 ZSTD_TAG=v1.5.5
 ZSTD_SUCCESS=lib/libzstd.a
 


### PR DESCRIPTION
Previously this used the `master` branch of zstd however that branch no longer exists. Instead, this PR changes the reference to use the `release` branch.