### PR TITLE
Don't require bash to build dependencies

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 ROOT=$(pwd)
 DEPS_LOCATION=_build/deps


### PR DESCRIPTION
Bash is not always available and running `build_deps.sh` with `sh` works fine. 

We didn't have `bash` available in our CI environment and thought that making this change would make sense.
