### PR TITLE
Support context resets

### DIFF
--- a/c_src/ezstd_nif.h
+++ b/c_src/ezstd_nif.h
@@ -12,6 +12,9 @@ struct atoms
     ERL_NIF_TERM atomInvalidData;
     ERL_NIF_TERM atomFlush;
     ERL_NIF_TERM atomEnd;
+    ERL_NIF_TERM atomSessionOnly;
+    ERL_NIF_TERM atomParameters;
+    ERL_NIF_TERM atomSessionAndParameters;
 };
 
 extern atoms ATOMS;

--- a/src/ezstd.erl
+++ b/src/ezstd.erl
@@ -23,7 +23,9 @@
     create_decompression_context/1,
     set_decompression_parameter/3,
     select_ddict/2,
-    decompress_streaming/2
+    decompress_streaming/2,
+    reset_compression_context/2,
+    reset_decompression_context/2
 ]).
 
 -type zstd_compression_flag() :: 'zstd_c_compression_level'
@@ -36,6 +38,8 @@
       | 'zstd_c_strategy'.
 
 -type zstd_decompression_flag() :: 'zstd_d_window_log_max'.
+
+-type zstd_reset_directive() :: 'session_only' | 'parameters' | 'session_and_parameters'.
 
 -spec create_cdict(binary(), integer()) -> reference() | {error, any()}.
 create_cdict(Binary, CompressionLevel) ->
@@ -167,6 +171,32 @@ decompress_streaming_chunk(Context, Binary, Offset, Sofar, Attempts) ->
         Error ->
             Error
     end.
+
+%% @doc Resets the compression context to its initial state.
+%%
+%% The `ResetDirective' can be one of:
+%%
+%% - `session_only' - only resets the session state, keeping the parameters and dictionary.
+%%
+%% - `parameters' - only resets the parameters and dictionary, keeping the session state.
+%%
+%% - `session_and_parameters' - resets both the session state and the parameters (and dictionary).
+-spec reset_compression_context(reference(), zstd_reset_directive()) -> ok | {error, any()}.
+reset_compression_context(Context, ResetDirective) ->
+    ezstd_nif:reset_compression_context(Context, ResetDirective).
+
+%% @doc Resets the decompression context to its initial state.
+%%
+%% The `ResetDirective' can be one of:
+%%
+%% - `session_only' - only resets the session state, keeping the parameters and dictionary.
+%%
+%% - `parameters' - only resets the parameters and dictionary, keeping the session state.
+%%
+%% - `session_and_parameters' - resets both the session state and the parameters (and dictionary).
+-spec reset_decompression_context(reference(), zstd_reset_directive()) -> ok | {error, any()}.
+reset_decompression_context(Context, ResetDirective) ->
+    ezstd_nif:reset_decompression_context(Context, ResetDirective).
 
 % internals
 

--- a/src/ezstd_nif.erl
+++ b/src/ezstd_nif.erl
@@ -22,7 +22,9 @@
     create_decompression_context/1,
     select_ddict/2,
     set_decompression_parameter/3,
-    decompress_streaming_chunk/3
+    decompress_streaming_chunk/3,
+    reset_compression_context/2,
+    reset_decompression_context/2
 ]).
 
 %% nif functions
@@ -93,4 +95,10 @@ set_decompression_parameter(_CCtx, _Param, _Value) ->
     ?NOT_LOADED.
 
 decompress_streaming_chunk(_DCtx, _Binary, _Offset) ->
+    ?NOT_LOADED.
+
+reset_compression_context(_CCtx, _ResetDirective) ->
+    ?NOT_LOADED.
+
+reset_decompression_context(_DCtx, _ResetDirective) ->
     ?NOT_LOADED.


### PR DESCRIPTION
This adds `ezstd:reset_compression_context/2` and `ezstd:reset_decompression_context/2` to allow resetting the session of a context, the parameters (and dictionary) of a context, or both.

Under the hood, this just calls into the relevant `ZSTD_DCtx_reset` and `ZSTD_CCtx_reset` C functions and adds some Atom abstraction over the top.

One thing I am unsure about and may need some guidance on is whether it is necessary to free any dictionary resources after a context reset, as per the docs, when the `parameters` reset mode is selected:

>   - The parameters : changes all parameters back to "default".
                  This removes any reference to any dictionary too.
                  Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())

It mentions removal of references to dictionary, but I am not sure if this is something that needs to be explicitly handled.