### PR TITLE
Use cmake when available otherwise default to -O2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ compile_nif: get_deps
 clean_nif:
 	@make -C c_src clean
 
+clean_zstd: clean_nif
+	@make -C _build/deps/zstd clean
+	@cd _build/deps/zstd && git reset --hard
+
 compile:
 	${REBAR} compile
 

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+RunBench()
+{
+    if [ -z "$1" ]; then
+        echo "Compiling with CMAKE"
+        export CFLAGS=
+        export NO_CMAKE=
+    else
+        echo "Compiling with CFLAGS=$1 and NO_CMAKE=1"
+        export CFLAGS=$1
+        export NO_CMAKE=1
+    fi
+    make clean_zstd >> /dev/null
+    rebar3 compile >> /dev/null
+    rebar3 shell --script scripts/bench_compress.erl | grep -oE "AVG Time: .*"
+}
+
+RunBench "-g"
+RunBench "-O1"
+RunBench "-O2"
+RunBench "-O2 -march=native -mtune=native"
+RunBench
+
+# Benchmark results:
+#   Operating System: Linux
+#   CPU Information: AMD Ryzen 9 6900HS with Radeon Graphics
+#   Erlang 26.2.5.8
+#
+# Based on these decided to default to CFLAGS=-O2 if no cmake is available. As "-O2" is much faster than the default
+# and still keeps the binary compatible with other CPU architectures (e.g. for shipping releases).
+#
+# ./bench.sh
+# Compiling with CFLAGS=-g and NO_CMAKE=1
+# AVG Time: 2725070.5
+# Compiling with CFLAGS=-O1 and NO_CMAKE=1
+# AVG Time: 804889.6
+# Compiling with CFLAGS=-O2 and NO_CMAKE=1
+# AVG Time: 688417.6
+# Compiling with CFLAGS=-O2 -march=native -mtune=native and NO_CMAKE=1
+# AVG Time: 652656.5
+# Compiling with CMAKE
+# AVG Time: 631423.5

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -11,7 +11,7 @@ CPUS=`getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu`
 ZSTD_DESTINATION=zstd
 ZSTD_REPO=https://github.com/facebook/zstd.git
 ZSTD_BRANCH=release
-ZSTD_TAG=v1.5.5
+ZSTD_TAG=v1.5.6
 ZSTD_SUCCESS=lib/libzstd.a
 
 fail_check()
@@ -52,14 +52,23 @@ CheckoutLib()
 
 BuildLibrary()
 {
-    case $OS in
-        Linux)
-            export CFLAGS="-fPIC"
-            export CXXFLAGS="-fPIC"
-            ;;
-        *)
-            ;;
-    esac
+    if [ -z "$NO_CMAKE" ] && command -v cmake >/dev/null 2>&1; then
+        echo "Using cmake build system..."
+        cmake -S build/cmake
+    else
+        echo "cmake not found, using make directly..."
+        # Only define -O2 if CFLAGS is not already defined
+        export CFLAGS=${CFLAGS:-"-O2"}
+
+        case $OS in
+            Linux)
+                export CFLAGS="$CFLAGS -fPIC"
+                export CXXFLAGS="$CXXFLAGS -fPIC"
+                ;;
+            *)
+                ;;
+        esac
+    fi
 
     fail_check make -j $CPUS
     rm -rf lib/*.so

--- a/scripts/bench_compress.erl
+++ b/scripts/bench_compress.erl
@@ -1,0 +1,19 @@
+-module(bench_compress).
+-export([main/1]).
+
+generate_data(Size) ->
+    rand:seed({exsss,[244613567848733509|123751949107613598]}),
+    binary:copy(rand:bytes(trunc(Size/10)), 10).
+
+main(_) ->
+    Data = generate_data(50000000),
+    Times = bench(Data, 10),
+    io:format("AVG Time: ~p~n", [lists:sum(Times) / length(Times)]),
+    erlang:halt().
+
+bench(_Data, 0) ->
+    [];
+bench(Data, Count) ->
+    {Time, _} = timer:tc(ezstd, compress, [Data, 15]),
+    io:format("Time: ~p~n", [Time]),
+    [Time | bench(Data, Count - 1)].


### PR DESCRIPTION
Hey @silviucpp thanks for the great package.

On initial testing in my builds I realized that the default usage would end up slower than calling `zlib:deflate` so I did some benchmarking and found that there are no default optimization flags enabled downstream in zstd by default.

I've made these changes to either call `cmake` once before compilation so that the zstd Makefile is set to release mode and uses optimizations or alternatively if `cmake` is not available fall back to just `-O2`.

The rest of this PR are test scripts to build a certain CFLAGS configuration or invoke cmake and measure the compression performance. 

E.g. this is the performance on my Apple M1 on this test. Showing a 4.7x performance improvement with this PR

```bash
./bench.sh
Compiling with CFLAGS=-g and NO_CMAKE=1 (the previous default)
AVG Time: 1782776.8
Compiling with CFLAGS=-O1 and NO_CMAKE=1 
AVG Time: 375967.5
Compiling with CFLAGS=-O2 and NO_CMAKE=1 (new default if cmake not available)
AVG Time: 374304.0
Compiling with CFLAGS=-O2 -march=native -mtune=native and NO_CMAKE=1 
AVG Time: 391855.1
Compiling with CMAKE (new default)
AVG Time: 373830.2
```