### PR TITLE
Fix env.mk generation on OTP 29

### DIFF
--- a/c_src/nif.mk
+++ b/c_src/nif.mk
@@ -16,7 +16,7 @@ C_SRC_OUTPUT ?= $(PRIV_DIR)/$(PROJECT_NIF_NAME).so
 
 #regenerate all the time the env.mk
 ifneq ($(wildcard $(C_SRC_DIR)),)
-	GEN_ENV ?= $(shell erl -noshell -s init stop -eval "file:write_file(\"$(C_SRC_ENV)\", \
+	GEN_ENV ?= $(shell erl -noshell -eval "file:write_file(\"$(C_SRC_ENV)\", \
 		io_lib:format( \
 			\"ERTS_INCLUDE_DIR ?= ~s/erts-~s/include/~n\" \
 			\"ERL_INTERFACE_INCLUDE_DIR ?= ~s~n\" \


### PR DESCRIPTION
On OTP 29 the `init:stop` is preventing the code passed to `-eval` from running. The code already ended in `halt/0` so the `init:stop/0` is redundant. I tested this on OTP 27 and 28 and it worked as expected. Here is the error I was getting:

```
Error! Failed to eval: file:write_file("/Users/jtdowney/code/mylib/_build/default/lib/ezstd/c_src/env.mk", io_lib:format( "ERTS_INCLUDE_DIR ?= ~s/erts-~s/include/~n" "ERL_INTERFACE_INCLUDE_DIR ?= ~s~n" "ERL_INTERFACE_LIB_DIR ?= ~s~n", [code:root_dir(), erlang:system_info(version), code:lib_dir(erl_interface, include), code:lib_dir(erl_interface, lib)])), halt().

nif.mk:31: /Users/jtdowney/code/mylib/_build/default/lib/ezstd/c_src/env.mk: No such file or directory
make[1]: *** No rule to make target `/Users/jtdowney/code/mylib/_build/default/lib/ezstd/c_src/env.mk'.  Stop.
make: *** [compile_nif] Error 2
===> Hook for compile failed!
```